### PR TITLE
fix: typos only

### DIFF
--- a/lib/utils/make-sreenshots-with-errors-borderd.ts
+++ b/lib/utils/make-sreenshots-with-errors-borderd.ts
@@ -20,7 +20,7 @@ export async function makeScreenshotsWithErrorsBorderd(
         debug(
             config.debugMode,
             e.message +
-                '. Ignored because normally it means that Function already there. (Adding debug to winwo in expose object)',
+                '. Ignored because normally it means that Function already there. (Adding debug to window in expose object)',
         );
     }
     for (const result of resultByUrl.violations) {

--- a/lib/utils/mark-all-tabable-items.ts
+++ b/lib/utils/mark-all-tabable-items.ts
@@ -21,7 +21,7 @@ export async function markAllTabableItems(
     try {
         await page.exposeFunction('debug', debug);
     } catch (e) {
-        error(e.message + '. Ignored because normally it means thtat Function already there');
+        error(e.message + '. Ignored because normally it means that Function is already there');
     }
     let runs = 0;
     let elementsFromEvaluation: ElementsFromEvaluation = {
@@ -49,7 +49,7 @@ export async function markAllTabableItems(
                             }
                         }
 
-                        await window.debug(debugMode, elementExtraAdjusting + ' px are extra adjustet');
+                        await window.debug(debugMode, elementExtraAdjusting + ' px are extra adjusted');
 
                         tabNumberSpan.setAttribute(
                             'style',


### PR DESCRIPTION
This PR fixes a couple of typos in `mark-all-tabbable-items.ts`. Thanks for this project!