### PR TITLE
Improve query selector for cases when a tabable element ID starts with a number

### DIFF
--- a/lib/utils/mark-all-tabable-items.ts
+++ b/lib/utils/mark-all-tabable-items.ts
@@ -75,7 +75,7 @@ export async function markAllTabableItems(
                     el.id = 'tabitem' + tabItemCount;
                     tabItemCount++;
                 }
-                return '#' + el.id;
+                return "[id='" + el.id + "']";
             });
     });
 


### PR DESCRIPTION
If a tabable element's ID starts with a number, the query selector like
`#123456789` can trigger a "not a valid selector" error. The solution here is to
use an alternate representation of the selector: `[id='#123456789']`.

Fixes forsti0506/a11y-sitechecker#230